### PR TITLE
feat(chat): 대화 목록/상세 API 엔드포인트 연동

### DIFF
--- a/backend/logs/spring.log
+++ b/backend/logs/spring.log
@@ -676,3 +676,93 @@ This generated password is for development use only. Your security configuration
 2025-07-08T06:59:06.583Z  INFO 1 --- [AiCareerChatBot] [SpringApplicationShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
 2025-07-08T06:59:06.585Z  INFO 1 --- [AiCareerChatBot] [SpringApplicationShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown initiated...
 2025-07-08T06:59:06.593Z  INFO 1 --- [AiCareerChatBot] [SpringApplicationShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown completed.
+2025-07-08T13:28:35.087Z  INFO 1 --- [AiCareerChatBot] [main] A.demo.AiCareerChatBotApplication        : Starting AiCareerChatBotApplication v0.0.1-SNAPSHOT using Java 17.0.15 with PID 1 (/app/app.jar started by root in /app)
+2025-07-08T13:28:35.090Z  INFO 1 --- [AiCareerChatBot] [main] A.demo.AiCareerChatBotApplication        : The following 1 profile is active: "prod"
+2025-07-08T13:28:35.811Z  INFO 1 --- [AiCareerChatBot] [main] .s.d.r.c.RepositoryConfigurationDelegate : Multiple Spring Data modules found, entering strict repository configuration mode
+2025-07-08T13:28:35.813Z  INFO 1 --- [AiCareerChatBot] [main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2025-07-08T13:28:35.948Z  INFO 1 --- [AiCareerChatBot] [main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 128 ms. Found 2 JPA repository interfaces.
+2025-07-08T13:28:35.966Z  INFO 1 --- [AiCareerChatBot] [main] .s.d.r.c.RepositoryConfigurationDelegate : Multiple Spring Data modules found, entering strict repository configuration mode
+2025-07-08T13:28:35.968Z  INFO 1 --- [AiCareerChatBot] [main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data Redis repositories in DEFAULT mode.
+2025-07-08T13:28:35.990Z  INFO 1 --- [AiCareerChatBot] [main] .RepositoryConfigurationExtensionSupport : Spring Data Redis - Could not safely identify store assignment for repository candidate interface AiCareerChatBot.demo.repository.ChatMessageRepository; If you want this repository to be a Redis repository, consider annotating your entities with one of these annotations: org.springframework.data.redis.core.RedisHash (preferred), or consider extending one of the following types with your repository: org.springframework.data.keyvalue.repository.KeyValueRepository
+2025-07-08T13:28:35.990Z  INFO 1 --- [AiCareerChatBot] [main] .RepositoryConfigurationExtensionSupport : Spring Data Redis - Could not safely identify store assignment for repository candidate interface AiCareerChatBot.demo.repository.UserRepository; If you want this repository to be a Redis repository, consider annotating your entities with one of these annotations: org.springframework.data.redis.core.RedisHash (preferred), or consider extending one of the following types with your repository: org.springframework.data.keyvalue.repository.KeyValueRepository
+2025-07-08T13:28:35.991Z  INFO 1 --- [AiCareerChatBot] [main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 7 ms. Found 0 Redis repository interfaces.
+2025-07-08T13:28:36.498Z  INFO 1 --- [AiCareerChatBot] [main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port 8080 (http)
+2025-07-08T13:28:36.515Z  INFO 1 --- [AiCareerChatBot] [main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
+2025-07-08T13:28:36.516Z  INFO 1 --- [AiCareerChatBot] [main] o.apache.catalina.core.StandardEngine    : Starting Servlet engine: [Apache Tomcat/10.1.42]
+2025-07-08T13:28:36.545Z  INFO 1 --- [AiCareerChatBot] [main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
+2025-07-08T13:28:36.546Z  INFO 1 --- [AiCareerChatBot] [main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 1412 ms
+2025-07-08T13:28:36.661Z  INFO 1 --- [AiCareerChatBot] [main] o.hibernate.jpa.internal.util.LogHelper  : HHH000204: Processing PersistenceUnitInfo [name: default]
+2025-07-08T13:28:36.710Z  INFO 1 --- [AiCareerChatBot] [main] org.hibernate.Version                    : HHH000412: Hibernate ORM core version 6.6.18.Final
+2025-07-08T13:28:36.748Z  INFO 1 --- [AiCareerChatBot] [main] o.h.c.internal.RegionFactoryInitiator    : HHH000026: Second-level cache disabled
+2025-07-08T13:28:36.980Z  INFO 1 --- [AiCareerChatBot] [main] o.s.o.j.p.SpringPersistenceUnitInfo      : No LoadTimeWeaver setup: ignoring JPA class transformer
+2025-07-08T13:28:37.007Z  INFO 1 --- [AiCareerChatBot] [main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Starting...
+2025-07-08T13:28:37.090Z  INFO 1 --- [AiCareerChatBot] [main] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection org.mariadb.jdbc.Connection@4f3fec43
+2025-07-08T13:28:37.092Z  INFO 1 --- [AiCareerChatBot] [main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Start completed.
+2025-07-08T13:28:37.117Z  WARN 1 --- [AiCareerChatBot] [main] org.hibernate.orm.deprecation            : HHH90000025: MariaDBDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
+2025-07-08T13:28:37.137Z  INFO 1 --- [AiCareerChatBot] [main] org.hibernate.orm.connections.pooling    : HHH10001005: Database info:
+	Database JDBC URL [Connecting through datasource 'HikariDataSource (HikariPool-1)']
+	Database driver: undefined/unknown
+	Database version: 11.4.7
+	Autocommit mode: undefined/unknown
+	Isolation level: undefined/unknown
+	Minimum pool size: undefined/unknown
+	Maximum pool size: undefined/unknown
+2025-07-08T13:28:37.839Z  INFO 1 --- [AiCareerChatBot] [main] o.h.e.t.j.p.i.JtaPlatformInitiator       : HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
+2025-07-08T13:28:37.930Z  INFO 1 --- [AiCareerChatBot] [main] j.LocalContainerEntityManagerFactoryBean : Initialized JPA EntityManagerFactory for persistence unit 'default'
+2025-07-08T13:28:38.754Z  WARN 1 --- [AiCareerChatBot] [main] JpaBaseConfiguration$JpaWebConfiguration : spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
+2025-07-08T13:28:39.310Z  INFO 1 --- [AiCareerChatBot] [main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port 8080 (http) with context path '/'
+2025-07-08T13:28:39.325Z  INFO 1 --- [AiCareerChatBot] [main] A.demo.AiCareerChatBotApplication        : Started AiCareerChatBotApplication in 4.712 seconds (process running for 5.171)
+2025-07-08T13:28:48.588Z  INFO 1 --- [AiCareerChatBot] [http-nio-8080-exec-1] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring DispatcherServlet 'dispatcherServlet'
+2025-07-08T13:28:48.589Z  INFO 1 --- [AiCareerChatBot] [http-nio-8080-exec-1] o.s.web.servlet.DispatcherServlet        : Initializing Servlet 'dispatcherServlet'
+2025-07-08T13:28:48.591Z  INFO 1 --- [AiCareerChatBot] [http-nio-8080-exec-1] o.s.web.servlet.DispatcherServlet        : Completed initialization in 1 ms
+2025-07-08T13:28:49.433Z  INFO 1 --- [AiCareerChatBot] [http-nio-8080-exec-1] A.demo.service.AuthService               : 사용자 로그인 성공: test
+2025-07-08T13:33:29.898Z  INFO 1 --- [AiCareerChatBot] [SpringApplicationShutdownHook] o.s.b.w.e.tomcat.GracefulShutdown        : Commencing graceful shutdown. Waiting for active requests to complete
+2025-07-08T13:33:29.902Z  INFO 1 --- [AiCareerChatBot] [tomcat-shutdown] o.s.b.w.e.tomcat.GracefulShutdown        : Graceful shutdown complete
+2025-07-08T13:33:29.949Z  INFO 1 --- [AiCareerChatBot] [SpringApplicationShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
+2025-07-08T13:33:29.952Z  INFO 1 --- [AiCareerChatBot] [SpringApplicationShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown initiated...
+2025-07-08T13:33:29.957Z  INFO 1 --- [AiCareerChatBot] [SpringApplicationShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown completed.
+2025-07-08T13:35:00.625Z  INFO 1 --- [AiCareerChatBot] [main] A.demo.AiCareerChatBotApplication        : Starting AiCareerChatBotApplication v0.0.1-SNAPSHOT using Java 17.0.15 with PID 1 (/app/app.jar started by root in /app)
+2025-07-08T13:35:00.627Z  INFO 1 --- [AiCareerChatBot] [main] A.demo.AiCareerChatBotApplication        : The following 1 profile is active: "prod"
+2025-07-08T13:35:01.354Z  INFO 1 --- [AiCareerChatBot] [main] .s.d.r.c.RepositoryConfigurationDelegate : Multiple Spring Data modules found, entering strict repository configuration mode
+2025-07-08T13:35:01.355Z  INFO 1 --- [AiCareerChatBot] [main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2025-07-08T13:35:01.487Z  INFO 1 --- [AiCareerChatBot] [main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 124 ms. Found 2 JPA repository interfaces.
+2025-07-08T13:35:01.504Z  INFO 1 --- [AiCareerChatBot] [main] .s.d.r.c.RepositoryConfigurationDelegate : Multiple Spring Data modules found, entering strict repository configuration mode
+2025-07-08T13:35:01.506Z  INFO 1 --- [AiCareerChatBot] [main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data Redis repositories in DEFAULT mode.
+2025-07-08T13:35:01.522Z  INFO 1 --- [AiCareerChatBot] [main] .RepositoryConfigurationExtensionSupport : Spring Data Redis - Could not safely identify store assignment for repository candidate interface AiCareerChatBot.demo.repository.ChatMessageRepository; If you want this repository to be a Redis repository, consider annotating your entities with one of these annotations: org.springframework.data.redis.core.RedisHash (preferred), or consider extending one of the following types with your repository: org.springframework.data.keyvalue.repository.KeyValueRepository
+2025-07-08T13:35:01.523Z  INFO 1 --- [AiCareerChatBot] [main] .RepositoryConfigurationExtensionSupport : Spring Data Redis - Could not safely identify store assignment for repository candidate interface AiCareerChatBot.demo.repository.UserRepository; If you want this repository to be a Redis repository, consider annotating your entities with one of these annotations: org.springframework.data.redis.core.RedisHash (preferred), or consider extending one of the following types with your repository: org.springframework.data.keyvalue.repository.KeyValueRepository
+2025-07-08T13:35:01.524Z  INFO 1 --- [AiCareerChatBot] [main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 5 ms. Found 0 Redis repository interfaces.
+2025-07-08T13:35:02.020Z  INFO 1 --- [AiCareerChatBot] [main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port 8080 (http)
+2025-07-08T13:35:02.032Z  INFO 1 --- [AiCareerChatBot] [main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
+2025-07-08T13:35:02.033Z  INFO 1 --- [AiCareerChatBot] [main] o.apache.catalina.core.StandardEngine    : Starting Servlet engine: [Apache Tomcat/10.1.42]
+2025-07-08T13:35:02.060Z  INFO 1 --- [AiCareerChatBot] [main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
+2025-07-08T13:35:02.062Z  INFO 1 --- [AiCareerChatBot] [main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 1390 ms
+2025-07-08T13:35:02.183Z  INFO 1 --- [AiCareerChatBot] [main] o.hibernate.jpa.internal.util.LogHelper  : HHH000204: Processing PersistenceUnitInfo [name: default]
+2025-07-08T13:35:02.233Z  INFO 1 --- [AiCareerChatBot] [main] org.hibernate.Version                    : HHH000412: Hibernate ORM core version 6.6.18.Final
+2025-07-08T13:35:02.269Z  INFO 1 --- [AiCareerChatBot] [main] o.h.c.internal.RegionFactoryInitiator    : HHH000026: Second-level cache disabled
+2025-07-08T13:35:02.507Z  INFO 1 --- [AiCareerChatBot] [main] o.s.o.j.p.SpringPersistenceUnitInfo      : No LoadTimeWeaver setup: ignoring JPA class transformer
+2025-07-08T13:35:02.533Z  INFO 1 --- [AiCareerChatBot] [main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Starting...
+2025-07-08T13:35:02.615Z  INFO 1 --- [AiCareerChatBot] [main] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection org.mariadb.jdbc.Connection@3c544c9
+2025-07-08T13:35:02.617Z  INFO 1 --- [AiCareerChatBot] [main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Start completed.
+2025-07-08T13:35:02.642Z  WARN 1 --- [AiCareerChatBot] [main] org.hibernate.orm.deprecation            : HHH90000025: MariaDBDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
+2025-07-08T13:35:02.659Z  INFO 1 --- [AiCareerChatBot] [main] org.hibernate.orm.connections.pooling    : HHH10001005: Database info:
+	Database JDBC URL [Connecting through datasource 'HikariDataSource (HikariPool-1)']
+	Database driver: undefined/unknown
+	Database version: 11.4.7
+	Autocommit mode: undefined/unknown
+	Isolation level: undefined/unknown
+	Minimum pool size: undefined/unknown
+	Maximum pool size: undefined/unknown
+2025-07-08T13:35:03.327Z  INFO 1 --- [AiCareerChatBot] [main] o.h.e.t.j.p.i.JtaPlatformInitiator       : HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
+2025-07-08T13:35:03.413Z  INFO 1 --- [AiCareerChatBot] [main] j.LocalContainerEntityManagerFactoryBean : Initialized JPA EntityManagerFactory for persistence unit 'default'
+2025-07-08T13:35:04.175Z  WARN 1 --- [AiCareerChatBot] [main] JpaBaseConfiguration$JpaWebConfiguration : spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
+2025-07-08T13:35:04.724Z  INFO 1 --- [AiCareerChatBot] [main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port 8080 (http) with context path '/'
+2025-07-08T13:35:04.752Z  INFO 1 --- [AiCareerChatBot] [main] A.demo.AiCareerChatBotApplication        : Started AiCareerChatBotApplication in 4.53 seconds (process running for 4.963)
+2025-07-08T13:35:43.597Z  INFO 1 --- [AiCareerChatBot] [http-nio-8080-exec-1] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring DispatcherServlet 'dispatcherServlet'
+2025-07-08T13:35:43.598Z  INFO 1 --- [AiCareerChatBot] [http-nio-8080-exec-1] o.s.web.servlet.DispatcherServlet        : Initializing Servlet 'dispatcherServlet'
+2025-07-08T13:35:43.601Z  INFO 1 --- [AiCareerChatBot] [http-nio-8080-exec-1] o.s.web.servlet.DispatcherServlet        : Completed initialization in 2 ms
+2025-07-08T13:35:44.492Z  INFO 1 --- [AiCareerChatBot] [http-nio-8080-exec-1] A.demo.service.AuthService               : 사용자 로그인 성공: test
+2025-07-08T13:36:54.633Z  INFO 1 --- [AiCareerChatBot] [SpringApplicationShutdownHook] o.s.b.w.e.tomcat.GracefulShutdown        : Commencing graceful shutdown. Waiting for active requests to complete
+2025-07-08T13:36:54.637Z  INFO 1 --- [AiCareerChatBot] [tomcat-shutdown] o.s.b.w.e.tomcat.GracefulShutdown        : Graceful shutdown complete
+2025-07-08T13:36:54.674Z  INFO 1 --- [AiCareerChatBot] [SpringApplicationShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
+2025-07-08T13:36:54.677Z  INFO 1 --- [AiCareerChatBot] [SpringApplicationShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown initiated...
+2025-07-08T13:36:54.682Z  INFO 1 --- [AiCareerChatBot] [SpringApplicationShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown completed.

--- a/frontend/src/components/ConversationList.jsx
+++ b/frontend/src/components/ConversationList.jsx
@@ -1,44 +1,83 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { MessageSquareText, Trash2 } from 'lucide-react';
-
-// Mock 데이터 임포트: 실제 API 연동 시에는 이 부분을 제거하고 서버에서 데이터를 가져옵니다.
+import axiosInstance from '../utils/axiosInstance';
+import { notifyError, notifySuccess } from './Notification';
+import LoadingSpinner from './LoadingSpinner';
 import { MOCK_CONVERSATIONS } from '../mocks/data.js';
 
 /**
- * 저장된 대화 목록을 표시하는 컴포넌트입니다.
+ * 저장된 대화 목록을 API 또는 Mock 데이터를 통해 불러와 표시하는 컴포넌트입니다.
  * 각 대화를 클릭하여 상세 보기로 이동하거나 삭제할 수 있습니다.
  */
 function ConversationList() {
     const [conversations, setConversations] = useState([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState(null);
     const navigate = useNavigate();
 
-    // 컴포넌트 마운트 시 Mock 데이터 로드
     useEffect(() => {
-        setConversations(MOCK_CONVERSATIONS);
-    }, []); // 빈 배열은 컴포넌트가 처음 렌더링될 때 한 번만 실행됨을 의미합니다.
+        const fetchConversations = async () => {
+            setIsLoading(true);
+            try {
+                const response = await axiosInstance.get('/chat/history');
+                setConversations(response.data);
+            } catch (err) {
+                setError("대화 목록을 불러오는 중 오류가 발생했습니다.");
+                console.error("Fetch conversations error:", err);
+            } finally {
+                setIsLoading(false);
+            }
+        };
 
-    /**
-     * 대화 목록 아이템 클릭 시 해당 대화의 상세 페이지로 이동합니다.
-     * @param {string} id - 클릭된 대화의 고유 ID
-     */
+        // 개발 환경에서는 Mock 데이터를, 실제 환경에서는 API를 호출합니다.
+        if (import.meta.env.DEV) {
+            console.log("ConversationList: 개발 모드이므로 목업 데이터를 사용합니다.");
+            setTimeout(() => {
+                setConversations(MOCK_CONVERSATIONS);
+                setIsLoading(false);
+            }, 500);
+        } else {
+            fetchConversations();
+        }
+    }, []);
+
     const handleItemClick = (id) => {
         navigate(`/chatbot/${id}`);
     };
 
-    /**
-     * 대화 삭제 버튼 클릭 시 해당 대화를 목록에서 제거합니다.
-     * @param {React.MouseEvent} e - 클릭 이벤트 객체 (이벤트 버블링 방지를 위해 사용)
-     * @param {string} id - 삭제할 대화의 고유 ID
-     */
-    const handleDelete = (e, id) => {
-        e.stopPropagation(); // 부모 요소의 onClick 이벤트(handleItemClick)가 실행되는 것을 방지합니다.
-        if (window.confirm('이 대화를 삭제하시겠습니까?')) {
-            setConversations((prev) => prev.filter((c) => c._id !== id));
+    const handleDelete = async (e, id) => {
+        e.stopPropagation();
+        if (window.confirm('이 대화를 정말 삭제하시겠습니까?')) {
+            const originalConversations = [...conversations];
+            setConversations(prev => prev.filter(c => c._id !== id));
+
+            try {
+                if (!import.meta.env.DEV) {
+                    await axiosInstance.delete(`/chat/${id}`);
+                }
+                notifySuccess("대화가 삭제되었습니다.");
+            } catch (err) {
+                notifyError("대화 삭제 중 오류가 발생했습니다.");
+                setConversations(originalConversations); // API 실패 시 UI 롤백
+                console.error("Delete conversation error:", err);
+            }
         }
     };
 
-    // 저장된 대화가 없을 경우 표시할 UI
+    if (isLoading) {
+        return (
+            <div className="flex justify-center items-center py-10">
+                <LoadingSpinner size="md" />
+                <span className="ml-4 text-gray-500 dark:text-gray-400">대화 목록을 불러오는 중...</span>
+            </div>
+        );
+    }
+
+    if (error) {
+        return <p className="py-10 text-center text-red-500 dark:text-red-400">{error}</p>;
+    }
+
     if (conversations.length === 0) {
         return <p className="py-10 text-center text-gray-500 dark:text-gray-400">저장된 대화가 없습니다.</p>;
     }
@@ -47,35 +86,29 @@ function ConversationList() {
         <div className="space-y-1">
             {conversations.map((conv) => (
                 <div
-                    key={conv._id} // 각 대화 항목의 고유 ID를 key로 사용합니다.
+                    key={conv._id}
                     onClick={() => handleItemClick(conv._id)}
                     className="group flex cursor-pointer items-center rounded-xl p-4 transition-colors duration-200 hover:bg-gray-100 dark:hover:bg-gray-700/50"
                 >
-                    {/* 대화 아이콘 영역 */}
                     <div className="mr-4 flex-shrink-0">
                         <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-200 dark:bg-gray-700">
                             <MessageSquareText className="h-6 w-6 text-gray-500 dark:text-gray-400" />
                         </div>
                     </div>
-
-                    {/* 대화 제목 및 요약 영역 */}
                     <div className="flex-grow overflow-hidden">
                         <p className="truncate text-lg font-bold text-gray-800 dark:text-gray-100">{conv.title}</p>
                         <p className="mt-1 truncate text-sm text-gray-500 dark:text-gray-400">
-                            {conv.summary?.questions?.[0] || '내용 없음'}
+                            {conv.summary?.questions?.[0] || '요약 정보 없음'}
                         </p>
                     </div>
-
-                    {/* 시간 및 삭제 버튼 영역 */}
                     <div className="ml-4 flex h-full flex-shrink-0 flex-col items-end text-right">
                         <p className="mb-1 text-xs text-gray-400 dark:text-gray-500">
-                            {/* createdAt 날짜를 현지 시간으로 포맷하여 표시 */}
                             {new Date(conv.createdAt).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}
                         </p>
                         <button
                             onClick={(e) => handleDelete(e, conv._id)}
                             className="text-gray-400 opacity-0 transition-all duration-200 hover:text-red-500 group-hover:opacity-100 dark:text-gray-500 dark:hover:text-red-500"
-                            title="삭제" // 툴팁 제공
+                            title="삭제"
                         >
                             <Trash2 size={16} />
                         </button>

--- a/frontend/src/pages/ChatbotPage.jsx
+++ b/frontend/src/pages/ChatbotPage.jsx
@@ -1,219 +1,118 @@
-// src/pages/ChatbotPage.jsx
-
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
-import { useParams, Link } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
-
-// 컴포넌트 임포트
+import ResumeUploadSection from '../components/ResumeUploadSection';
 import ChatWindow from '../components/ChatWindow';
 import ChatInput from '../components/ChatInput';
-
-// Redux 액션 임포트
-import { addUserMessage, addAiMessage, clearChat, startQuestionChat, setMessages, setChatError } from '../features/chat/chatSlice';
-
-// 알림 컴포넌트 임포트
-import { notifyError } from '../components/Notification';
-
-// API 호출을 위한 axiosInstance 임포트 (Authorization 헤더 자동 추가)
+import { addUserMessage, addAiMessage, setMessages, clearChat, setAiTyping } from '../features/chat/chatSlice';
 import axiosInstance from '../utils/axiosInstance';
-// *** 중요: axios.isAxiosError를 사용하기 위해 axios 자체도 임포트합니다. ***
-import axios from 'axios'; 
+import { MOCK_CONVERSATIONS } from '../mocks/data.js';
 
-/**
- * 특정 대화 기록을 표시하고 사용자와 AI 간의 대화를 관리하는 페이지 컴포넌트입니다.
- * URL 파라미터에서 대화 ID를 받아 백엔드로부터 대화 기록을 불러옵니다.
- */
 function ChatbotPage() {
+    const { id: urlId } = useParams();
+    const navigate = useNavigate();
     const dispatch = useDispatch();
-    const { id } = useParams(); // URL 파라미터에서 대화 ID (예: conv_resume_1) 가져오기
 
-    // Redux 스토어에서 채팅 관련 상태를 가져옵니다.
-    const { messages: chatMessages, isAiTyping, error: chatError } = useSelector((state) => state.chat);
-    // console.log("ChatbotPage - useSelector로 가져온 chatMessages (초기/업데이트):", chatMessages); // 디버깅용 로그
+    const { messages, isAiTyping } = useSelector((state) => state.chat);
+    const [pageTitle, setPageTitle] = useState("AI 커리어 챗봇");
 
-    // 메시지 목록의 끝으로 자동 스크롤하기 위한 ref
-    const messagesEndRef = useRef(null);
-
-    /**
-     * 컴포넌트가 언마운트될 때 Redux 채팅 상태를 초기화합니다.
-     * 새로운 대화로 이동하거나 페이지를 벗어날 때 이전 기록을 정리합니다.
-     */
     useEffect(() => {
+        // 페이지를 벗어날 때 Redux의 채팅 상태를 깨끗하게 정리합니다.
         return () => {
-            dispatch(clearChat()); // 채팅 기록 및 관련 상태 초기화
+            dispatch(clearChat());
         };
     }, [dispatch]);
-
-    /**
-     * URL의 대화 ID(`id`)가 변경될 때마다 해당 대화 기록을 백엔드에서 불러옵니다.
-     * 이 함수는 `useEffect` 내부에서 비동기적으로 실행됩니다.
-     */
+    
     useEffect(() => {
-        if (id) { // 대화 ID가 존재할 경우에만 대화 기록을 불러옵니다.
-            const fetchConversation = async () => {
-                try {
-                    // axiosInstance를 사용하여 백엔드 API 호출: 인증 토큰이 자동으로 포함됩니다.
-                    // baseURL이 이미 '/api'로 설정되어 있으므로 경로에서 '/api'를 제거합니다.
-                    const response = await axiosInstance.get(`/conversations/${id}`);
-                    
-                    // Axios는 응답 데이터를 `response.data`에 담아줍니다.
-                    const data = response.data;
-
-                    // --- 백엔드 응답 데이터 확인 및 방어 로직 ---
-                    console.log("백엔드로부터 받은 원본 데이터 (fetchConversation):", data);
-
-                    let loadedMessages = []; // 기본적으로 빈 배열로 초기화하여 런타임 오류 방지
-
-                    // 백엔드 응답 데이터 구조에 따라 메시지 배열에 접근합니다.
-                    // 이 부분이 중요합니다! 백엔드가 어떤 형태로 메시지 배열을 주는지 정확히 확인하세요.
-                    // 예시 1: 백엔드가 `{ messages: [...] }` 형태로 보낼 경우 (가장 일반적)
-                    if (data && Array.isArray(data.messages)) {
-                        loadedMessages = data.messages;
-                    }
-                    // 예시 2: 백엔드가 `{ conversation: { _id, messages: [...] } }` 형태로 보낼 경우
-                    // else if (data && data.conversation && Array.isArray(data.conversation.messages)) {
-                    //    loadedMessages = data.conversation.messages;
-                    // }
-                    // 예시 3: 백엔드가 직접 메시지 배열 `[...]`을 보낼 경우
-                    else if (Array.isArray(data)) {
-                        loadedMessages = data;
-                    }
-                    // 그 외의 경우 (예: data가 빈 객체 {}이거나 null 등), loadedMessages는 여전히 빈 배열로 유지됩니다.
-                    
-                    console.log("setMessages에 전달될 loadedMessages (정제 후):", loadedMessages);
-
-                    // Redux 스토어의 messages 상태를 업데이트합니다.
-                    // chatSlice의 setMessages 리듀서에서 이미 배열 여부를 검사하지만, 여기서도 확실히 배열을 전달.
-                    dispatch(setMessages(loadedMessages));
-
-                } catch (error) {
-                    console.error("대화 기록 로드 중 오류 발생:", error);
-                    let errorMessage = '대화 기록을 불러오는 데 실패했습니다. ';
-                    
-                    // *** 수정: axios.isAxiosError를 사용합니다. ***
-                    if (axios.isAxiosError(error) && error.response) { // axiosInstance가 아닌 axios의 isAxiosError 사용
-                        if (error.response.status === 401) {
-                            errorMessage += error.response.data?.message || '인증이 필요합니다. 다시 로그인해주세요.';
-                            // 선택적으로 여기서 로그아웃 액션 디스패치 가능: store.dispatch(logout());
-                        } else if (error.response.status === 404) {
-                            errorMessage += error.response.data?.message || '해당 대화 기록을 찾을 수 없습니다.';
-                        } else if (error.response.status >= 500) {
-                            errorMessage += '서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.';
-                        } else {
-                            errorMessage += error.response.data?.message || `(코드: ${error.response.status})`;
-                        }
-                    } else if (axios.isAxiosError(error) && error.request) { // axiosInstance가 아닌 axios의 isAxiosError 사용
-                        errorMessage += '서버에 연결할 수 없습니다. 네트워크 상태를 확인해주세요.';
-                    } else {
-                        errorMessage += error.message || '알 수 없는 오류가 발생했습니다.';
-                    }
-
-                    dispatch(setChatError(errorMessage)); // Redux 스토어에 에러 메시지 설정
-                    notifyError(errorMessage); // 사용자에게 알림 표시 (axiosInstance 인터셉터와 중복될 수 있음)
-                    dispatch(setMessages([])); // 에러 발생 시 메시지 목록을 빈 배열로 초기화하여 렌더링 오류 방지
+        const fetchConversationById = async (id) => {
+            dispatch(setAiTyping(true));
+            try {
+                let loadedData;
+                if (import.meta.env.DEV) {
+                    console.log(`ChatbotPage: 개발 모드이므로 ID(${id})에 해당하는 목업 데이터를 찾습니다.`);
+                    loadedData = MOCK_CONVERSATIONS.find(conv => conv._id === id);
+                } else {
+                    const response = await axiosInstance.get(`/chat/${id}`);
+                    loadedData = response.data;
                 }
-            };
-            fetchConversation();
+
+                if (loadedData) {
+                    const formattedMessages = loadedData.chatHistory.map(msg => ({
+                        sender: msg.role === 'assistant' ? 'ai' : 'user', text: msg.content
+                    }));
+                    dispatch(setMessages(formattedMessages));
+                    setPageTitle(loadedData.title);
+                } else {
+                    navigate('/history');
+                }
+            } catch (error) {
+                console.error("Error fetching conversation:", error);
+                navigate('/history');
+            } finally {
+                dispatch(setAiTyping(false));
+            }
+        };
+
+        if (urlId) {
+            fetchConversationById(urlId);
         } else {
-            // ID가 없으면 새 대화를 시작하도록 채팅 상태를 초기화합니다.
             dispatch(clearChat());
+            dispatch(addAiMessage('안녕하세요! AI 커리어 챗봇입니다. 무엇을 도와드릴까요?'));
+            setPageTitle("AI 커리어 챗봇 (새 대화)");
         }
-    }, [id, dispatch]); // `id`와 `dispatch`가 변경될 때마다 이 `useEffect`가 실행됩니다.
+    }, [urlId, navigate, dispatch]);
 
-    /**
-     * `chatMessages` 상태가 변경될 때마다 채팅창을 최신 메시지 위치로 자동 스크롤합니다.
-     */
-    useEffect(() => {
-        messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-    }, [chatMessages]);
-
-    /**
-     * 사용자 메시지 전송 및 AI 응답 시뮬레이션을 처리합니다.
-     * @param {string} messageText - 사용자가 입력한 메시지 텍스트
-     */
     const handleSendMessage = async (messageText) => {
-        if (!messageText.trim() || isAiTyping) return; // 메시지가 비었거나 AI가 타이핑 중이면 전송 방지
-
-        dispatch(addUserMessage(messageText)); // 사용자 메시지를 Redux 스토어에 추가
-
-        // TODO: 실제 AI API 호출 및 응답 처리 로직을 여기에 구현합니다.
-        // 이 API도 인증이 필요하다면 axiosInstance를 사용해야 합니다.
+        if (!messageText.trim() || isAiTyping) return;
+        dispatch(addUserMessage(messageText));
+        
         try {
-            // 예시: 실제 AI 응답 API 호출 시 axiosInstance 사용
-            // const aiResponse = await axiosInstance.post('/chat', { message: messageText, conversationId: id });
-            // dispatch(addAiMessage(aiResponse.data.text));
-            
-            await new Promise(resolve => setTimeout(resolve, 1500)); // API 호출 시뮬레이션 지연
-            dispatch(addAiMessage(`"${messageText.substring(0, Math.min(messageText.length, 15))}..."에 대한 데모 AI 답변입니다.`));
+            // TODO: 실제 AI 응답 API 호출
+            await new Promise(resolve => setTimeout(resolve, 1500));
+            const aiResponse = `"${messageText}"에 대한 AI의 데모 응답입니다.`;
+            dispatch(addAiMessage(aiResponse));
         } catch (error) {
-            console.error("메시지 전송 중 오류 발생:", error);
-            // 메시지 전송 에러도 axiosInstance 인터셉터에서 처리되므로, 여기서 notifyError는 중복될 수 있습니다.
-            dispatch(setChatError('메시지 전송 중 오류가 발생했습니다.'));
-            notifyError('메시지 전송에 실패했습니다.');
+            dispatch(addAiMessage("죄송합니다, 응답 생성 중 오류가 발생했습니다."));
         }
     };
 
-    /**
-     * 현재 채팅 기록을 초기화합니다.
-     */
-    const handleClearChat = () => {
-        dispatch(clearChat()); // Redux 스토어의 채팅 기록 초기화
-        // TODO: 필요한 경우 백엔드에 대화 초기화 또는 저장 API 호출 (대화 ID가 있을 경우)
+    const handleContextSubmit = (context) => {
+        const firstMessage = context.file 
+            ? `파일(${context.file.name})을 업로드했습니다. 이 내용을 바탕으로 대화를 시작합니다.`
+            : `다음 내용을 바탕으로 대화를 시작합니다:\n\n${context.text}`;
+        dispatch(clearChat());
+        dispatch(addAiMessage(firstMessage));
     };
-
-    /**
-     * 예시 질문 클릭 시 해당 질문 텍스트로 메시지를 즉시 전송합니다.
-     * @param {string} question - 클릭된 예시 질문 텍스트
-     */
-    const handleExampleQuestionClick = (question) => {
-        handleSendMessage(question); // ChatInput에서 받은 질문을 직접 전송
-    };
-
-    // 채팅 입력 컴포넌트에서 사용할 예시 질문 목록
-    const exampleQuestions = [
-        "이전 대화 요약해줘.",
-        "이 질문은 어떤 의미로 받아들여야 할까?",
-        "대화 저장하는 방법 알려줘."
-    ];
 
     return (
         <div className="min-h-screen bg-gray-100 dark:bg-gray-900 font-inter">
             <div className="container mx-auto p-6 flex flex-col h-screen">
-                {/* 페이지 헤더 섹션 */}
                 <div className="flex items-center mb-6 flex-shrink-0">
-                    {/* 대화 기록 목록 페이지로 돌아가는 링크 */}
-                    <Link
-                        to="/history"
-                        className="p-2 mr-4 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
-                        aria-label="대화 기록 목록으로 돌아가기"
-                    >
+                    <Link to={urlId ? "/history" : "/dashboard"} className="p-2 mr-4 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700">
                         <ArrowLeft className="w-6 h-6 text-gray-800 dark:text-gray-200" />
                     </Link>
-                    {/* 페이지 제목 */}
-                    <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-50">
-                        대화 기록 보기
+                    <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-50 truncate">
+                        {pageTitle}
                     </h1>
                 </div>
-
-                {/* 메인 채팅 인터페이스 영역 */}
-                <main className="flex-1 flex flex-col bg-white rounded-2xl shadow-lg border border-gray-200 dark:bg-gray-800 dark:border-gray-700 h-full">
-                    {/* 채팅 메시지 표시 영역 */}
-                    <ChatWindow
-                        messages={chatMessages}
-                        isThinking={isAiTyping}
-                        messagesEndRef={messagesEndRef} // ChatWindow 내부에서 자동 스크롤용으로 사용될 ref 전달
-                    />
-
-                    {/* 챗봇 입력 필드 및 컨트롤 버튼 */}
-                    <ChatInput
-                        onSendMessage={handleSendMessage}
-                        isLoading={isAiTyping}
-                        handleClearChat={handleClearChat}
-                        handleExampleQuestionClick={handleExampleQuestionClick}
-                        exampleQuestions={exampleQuestions}
-                    />
-                </main>
+                <div className="flex flex-1 gap-6 overflow-hidden">
+                    {!urlId && (
+                        <>
+                            <ResumeUploadSection onAnalyzeProp={handleContextSubmit} isLoading={isAiTyping} />
+                            <main className="flex-1 flex flex-col bg-white rounded-2xl shadow-lg border border-gray-200 dark:bg-gray-800 dark:border-gray-700 h-full">
+                                <ChatWindow messages={messages} isThinking={isAiTyping} />
+                                <ChatInput onSendMessage={handleSendMessage} isLoading={isAiTyping} />
+                            </main>
+                        </>
+                    )}
+                    {urlId && (
+                        <main className="w-full flex flex-col bg-white rounded-2xl shadow-lg border border-gray-200 dark:bg-gray-800 dark:border-gray-700 h-full">
+                            <ChatWindow messages={messages} isThinking={isAiTyping} />
+                            <ChatInput onSendMessage={handleSendMessage} isLoading={isAiTyping} />
+                        </main>
+                    )}
+                </div>
             </div>
         </div>
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "minipjt3",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
- 백엔드 `ChatController`의 실제 API 명세에 맞춰 프론트엔드 API 호출 주소를 수정합니다.
- `ConversationList`: 대화 목록 조회 API를 `/chat/history`로 변경합니다.
- `ChatbotPage`: 특정 대화 기록 조회 API를 `/chat/{id}`로 변경하고, 백엔드 `ChatMessage` DTO의 필드(`sender`, `message`)에 맞게 데이터 처리 로직을 수정합니다.
- 이 수정으로 API 호출 시 발생하던 401/404 에러를 해결하고, 실제 데이터 연동이 가능하도록 합니다.